### PR TITLE
Fixed pagination bug with filters. Added expandable craftable items

### DIFF
--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,9 +1,9 @@
 <nav class="flex justify-center mt-4" aria-label="Pagination">
   <ul class="inline-flex -space-x-px">
-    <%# Previous page %>
+    <!-- Previous page -->
     <% if local_assigns[:collection] && collection.prev_page %>
       <li>
-        <%= link_to raw('&laquo;'), url_for(page: collection.prev_page), class: "px-3 py-2 ml-0 leading-tight text-gray-500 bg-white border border-gray-300 rounded-l-lg hover:bg-gray-100 hover:text-gray-700" %>
+        <%= link_to raw('&laquo;'), url_for(request.query_parameters.merge(page: collection.prev_page)), class: "px-3 py-2 ml-0 leading-tight text-gray-500 bg-white border border-gray-300 rounded-l-lg hover:bg-gray-100 hover:text-gray-700" %>
       </li>
     <% else %>
       <li>
@@ -15,11 +15,11 @@
       <% if page %>
         <% if local_assigns[:collection] && page == collection.current_page %>
           <li>
-            <span class="px-3 py-2 leading-tight text-blue-600 bg-blue-50 border border-blue-300"> <%= page %> </span>
+            <span class="px-3 py-2 leading-tight text-blue-600 bg-blue-50 border border-blue-300"><%= page %></span>
           </li>
         <% else %>
           <li>
-            <%= link_to page, url_for(page: page), class: "px-3 py-2 leading-tight text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700" %>
+            <%= link_to page, url_for(request.query_parameters.merge(page: page)), class: "px-3 py-2 leading-tight text-gray-500 bg-white border border-gray-300 hover:bg-gray-100 hover:text-gray-700" %>
           </li>
         <% end %>
       <% else %>
@@ -29,10 +29,10 @@
       <% end %>
     <% end %>
 
-    <%# Next page %>
+    <!-- Next page -->
     <% if local_assigns[:collection] && collection.next_page %>
       <li>
-        <%= link_to raw('&raquo;'), url_for(page: collection.next_page), class: "px-3 py-2 leading-tight text-gray-500 bg-white border border-gray-300 rounded-r-lg hover:bg-gray-100 hover:text-gray-700" %>
+        <%= link_to raw('&raquo;'), url_for(request.query_parameters.merge(page: collection.next_page)), class: "px-3 py-2 leading-tight text-gray-500 bg-white border border-gray-300 rounded-r-lg hover:bg-gray-100 hover:text-gray-700" %>
       </li>
     <% else %>
       <li>

--- a/app/views/party_components/_component_list.html.erb
+++ b/app/views/party_components/_component_list.html.erb
@@ -1,6 +1,6 @@
 </table>
 <div class="mt-4">
-  <%= paginate @components %>
+  <%= paginate @components, params: request.query_parameters.except(:page) %>
 </div>
 <div data-controller="modal">
   <div class="mb-6">
@@ -23,12 +23,28 @@
       </thead>
       <tbody>
         <% @components.each do |component| %>
-          <tr>
-            <td class="border px-2 py-1"><%= component.display_name %></td>
+          <tr data-controller="expandable-row" data-expandable-row-component-id-value="<%= component.id %>">
+            <td class="border px-2 py-1 flex items-center gap-2">
+              <button
+                type="button"
+                class="expand-btn text-lg p-0 w-6 h-6 flex items-center justify-center bg-[#3F4045] text-[#FCFCFC] hover:bg-[#5D737E] hover:text-[#02111B] rounded transition focus:outline-none"
+                aria-label="Expand row"
+                data-expandable-row-component-id-value="<%= component.id %>"
+                data-action="click->expandable-row#toggle"
+              >
+                <span data-expandable-row-target="icon" aria-hidden="true">&#9654;</span>
+              </button>
+              <%= component.display_name %>
+            </td>
             <td class="border px-2 py-1"><%= component.monster_type&.titleize %></td>
             <td class="border px-2 py-1"><%= component.component_type&.titleize %></td>
             <td class="border px-2 py-1">
               <button type="button" class="px-3 py-1 rounded bg-green-600 text-white font-semibold hover:bg-green-800 transition" data-action="click->modal#open" data-modal-component-id-value="<%= component.id %>">Add</button>
+            </td>
+          </tr>
+          <tr id="craftable-items-<%= component.id %>" class="hidden">
+            <td colspan="4" class="p-0 border-t-0">
+              <%= render partial: "party_components/craftable_items_for_component", locals: { component: component } %>
             </td>
           </tr>
         <% end %>

--- a/app/views/party_components/_component_list.html.erb
+++ b/app/views/party_components/_component_list.html.erb
@@ -29,7 +29,6 @@
                 type="button"
                 class="expand-btn text-lg p-0 w-6 h-6 flex items-center justify-center bg-[#3F4045] text-[#FCFCFC] hover:bg-[#5D737E] hover:text-[#02111B] rounded transition focus:outline-none"
                 aria-label="Expand row"
-                data-expandable-row-component-id-value="<%= component.id %>"
                 data-action="click->expandable-row#toggle"
               >
                 <span data-expandable-row-target="icon" aria-hidden="true">&#9654;</span>

--- a/test/system/component_list_pagination_and_filtering_test.rb
+++ b/test/system/component_list_pagination_and_filtering_test.rb
@@ -1,0 +1,38 @@
+require "application_system_test_case"
+
+class ComponentListPaginationAndFilteringTest < ApplicationSystemTestCase
+  setup do
+    @party = Party.create!(name: "Pagination Test Party")
+    # Create enough components to require pagination
+    25.times do |i|
+      Component.create!(monster_type: Component.monster_types.keys.first, component_type: Component.component_types.keys.first, name: "Component#{i}")
+    end
+  end
+
+  test "pagination preserves filters and filters reset page" do
+    visit new_party_party_component_path(@party)
+    assert_text "Available Components"
+    # Go to page 2
+    click_link "2"
+    assert_current_path(/page=2/)
+    # Apply a filter (should reset to page 1)
+    select Component.monster_types.keys.first.titleize, from: "monster_type"
+    assert_no_current_path(/page=2/)
+    # Go to page 2 again with filter
+    click_link "2"
+    assert_current_path(/page=2/)
+    # Remove filter, should reset to page 1
+    select "Filter by Monster Type", from: "monster_type"
+    assert_no_current_path(/page=2/)
+  end
+
+  test "pagination and filters persist together" do
+    visit new_party_party_component_path(@party)
+    select Component.monster_types.keys.first.titleize, from: "monster_type"
+    click_link "2"
+    assert_current_path(/monster_type=.*&page=2/)
+    # Now change component type filter, should reset to page 1 but keep monster_type
+    select Component.component_types.keys.first.titleize, from: "component_type"
+    assert_current_path(/monster_type=.*&component_type=.*(?!page=2)/)
+  end
+end

--- a/test/system/party_inventory_test.rb
+++ b/test/system/party_inventory_test.rb
@@ -15,8 +15,8 @@ class PartyInventoryTest < ApplicationSystemTestCase
     select @component.monster_type.titleize, from: "monster_type"
     # Filter by component type
     select @component.component_type.titleize, from: "component_type"
-    # Add the component (use more specific selector for Add button)
-    within(:xpath, "//tr[td[contains(text(), '#{@component.display_name}')]]") do
+    # Add the component (find row by data attribute)
+    within("tr[data-expandable-row-component-id-value='#{@component.id}']") do
       find("button[data-action='click->modal#open']").click
     end
     # Modal should appear


### PR DESCRIPTION
This pull request enhances the component list UI with expandable rows, improves pagination and filtering behavior, and ensures query parameters are preserved across pagination actions. It also adds comprehensive system tests to verify the new pagination and filtering logic.

**Component List UI Improvements:**
- Added expandable rows to the `component_list` table, allowing users to view craftable items for each component by clicking an expand button. Each row now includes a button that toggles the display of additional details for the component. (`app/views/party_components/_component_list.html.erb`, [app/views/party_components/_component_list.html.erbL26-R49](diffhunk://#diff-945591b501b5c64caa9c8a08397b7c7fd8135b44ba3c92d380c038c0fab36afeL26-R49))
- Updated selectors in system tests to use the new data attributes for locating rows, ensuring tests remain robust with the new expandable row structure. (`test/system/party_inventory_test.rb`, [test/system/party_inventory_test.rbL18-R19](diffhunk://#diff-38a13f8cbeddd3cd2e9aa6580f7ed909979c101297fdf6510eb46ed152881bf8L18-R19))

**Pagination and Filtering Enhancements:**
- Modified pagination links in the `kaminari` paginator partial to preserve all existing query parameters (such as filters) when navigating between pages, ensuring that filters persist across pagination. (`app/views/kaminari/_paginator.html.erb`, [[1]](diffhunk://#diff-76806f01be0ee7bca0d01fb2dd6f2cb20c890a625b3a3bf07fb919eac63ed06fL3-R6) [[2]](diffhunk://#diff-76806f01be0ee7bca0d01fb2dd6f2cb20c890a625b3a3bf07fb919eac63ed06fL22-R22) [[3]](diffhunk://#diff-76806f01be0ee7bca0d01fb2dd6f2cb20c890a625b3a3bf07fb919eac63ed06fL32-R35)
- Updated the `paginate` helper in the component list view to exclude the `page` parameter, so when filters are changed, pagination resets to the first page as expected. (`app/views/party_components/_component_list.html.erb`, [app/views/party_components/_component_list.html.erbL3-R3](diffhunk://#diff-945591b501b5c64caa9c8a08397b7c7fd8135b44ba3c92d380c038c0fab36afeL3-R3))

**Testing:**
- Added a new system test (`ComponentListPaginationAndFilteringTest`) to verify that pagination and filters work together correctly: filters persist across pages, and changing filters resets pagination to the first page. (`test/system/component_list_pagination_and_filtering_test.rb`, [test/system/component_list_pagination_and_filtering_test.rbR1-R38](diffhunk://#diff-5cfd0c6e1d25db0a829616137e4dea7ecf8502000f554b3365a8acabee0d053cR1-R38))